### PR TITLE
add: depends on `com.intellij.modules.json`

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -17,6 +17,7 @@
     <depends>com.intellij.modules.rider</depends>
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.xdebugger</depends>
+    <depends>com.intellij.modules.json</depends>
 
     <resource-bundle>messages.ApplicationInsightsBundle</resource-bundle>
 


### PR DESCRIPTION
- fixes a startup exception on the latest Rider version `2024.3`

> com.intellij.json.JsonLanguage class removed
> Add [explicit dependency](https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html) on the newly extracted JSON plugin (com.intellij.modules.json) in plugin.xml.

See: https://plugins.jetbrains.com/docs/intellij/api-changes-list-2024.html#json-plugin-new-20243